### PR TITLE
Remove automatic plotting with sed_visualizer

### DIFF
--- a/visualizers/sed_visualizer.py
+++ b/visualizers/sed_visualizer.py
@@ -152,8 +152,6 @@ def main(argv):
         minimum_event_gap=parameters['minimum_event_gap'],
         publication_mode=publication_mode
     )
-
-    vis.show()
     
     if parameters['save_path'] is not None:
         vis.save(parameters['save_path'])


### PR DESCRIPTION
This slows down the batch processing with save_path, since it requires the user to close the figure to move to next file. If save_path is not provided, the figure will anyway be automatically prompted (line 159).